### PR TITLE
Add time-lagged 3D vectorscope rendering pipeline

### DIFF
--- a/Vectorscope/AudioIO.swift
+++ b/Vectorscope/AudioIO.swift
@@ -386,4 +386,10 @@ public final class StereoAudioSource {
         }
         return n
     }
+
+    public var currentSampleRate: Double {
+        indexQueue.sync {
+            currentFormat?.sampleRate ?? desiredSampleRate
+        }
+    }
 }

--- a/Vectorscope/Shaders.metal
+++ b/Vectorscope/Shaders.metal
@@ -1,43 +1,67 @@
 #include <metal_stdlib>
 using namespace metal;
 
-struct Uniforms {
-    float  gain;
+struct AudioLiftParams {
     uint   sampleCount;
-    float  pointSize;
-    float  aspectScaleY;
-    float  brightness;
+    uint   tauSamples;
+    float2 scaleXY;
+    float  scaleZ;
+    float  pad0;
+    float3 offset;
+    float  pad1;
+};
+
+struct LiftRenderUniforms {
+    float4x4 viewProjection;
+    float4   misc; // x: brightness, y: point size, z: sample count, w: unused
 };
 
 struct VSOut {
     float4 position [[position]];
     float4 color;
-    float  ptSize [[point_size]];
+    float  pointSize [[point_size]];
 };
 
-vertex VSOut vectorscope_vertex(uint vid [[vertex_id]],
-                                const device float* left  [[buffer(0)]],
-                                const device float* right [[buffer(1)]],
-                                constant Uniforms& u      [[buffer(2)]]) {
+kernel void liftStereoTimeLag(device const float* leftSamples   [[buffer(0)]],
+                              device const float* rightSamples  [[buffer(1)]],
+                              device float3* outXYZ             [[buffer(2)]],
+                              constant AudioLiftParams& params  [[buffer(3)]],
+                              uint tid                          [[thread_position_in_grid]]) {
+    if (tid >= params.sampleCount) {
+        return;
+    }
+
+    uint lagIndex = (tid >= params.tauSamples) ? (tid - params.tauSamples) : 0;
+
+    float x = leftSamples[tid];
+    float y = rightSamples[tid];
+    float z = leftSamples[lagIndex];
+
+    float3 lifted = float3(x * params.scaleXY.x,
+                           y * params.scaleXY.y,
+                           z * params.scaleZ) + params.offset;
+
+    outXYZ[tid] = lifted;
+}
+
+vertex VSOut vectorscope_lift_vertex(uint vid [[vertex_id]],
+                                     const device float3* positions [[buffer(0)]],
+                                     constant LiftRenderUniforms& uniforms [[buffer(1)]]) {
     VSOut out;
+    float3 p = positions[vid];
+    out.position = uniforms.viewProjection * float4(p, 1.0);
 
-    // Fetch normalized stereo samples and scale
-    float x = clamp(left[vid]  * u.gain, -1.0, 1.0);
-    float y = clamp(right[vid] * u.gain, -1.0, 1.0);
+    float total = max(1.0, uniforms.misc.z - 1.0);
+    float age = (total > 0.0) ? float(vid) / total : 0.0;
+    float alpha = clamp(uniforms.misc.x * age, 0.0, 1.0);
 
-    // Correct aspect so circles look circular on non-square viewports
-    float2 p = float2(x, y * u.aspectScaleY);
+    float depth = clamp(0.5 + 0.5 * tanh(p.z), 0.0, 1.0);
+    float3 cold = float3(0.2, 0.6, 1.0);
+    float3 warm = float3(1.0, 0.4, 0.6);
+    float3 baseColor = mix(cold, warm, depth);
 
-    out.position = float4(p, 0.0, 1.0);
-    out.ptSize   = max(1.0, u.pointSize);
-
-    // Linear fade by age: oldest (vid=0) is dim, newest (vid=sampleCount-1) is full brightness
-    // Handle small sampleCount to avoid div-by-zero.
-    float denom = max(1.0, float(max(1u, u.sampleCount) - 1u));
-    float ageFactor = clamp(float(vid) / denom, 0.0, 1.0);
-    float alpha = clamp(u.brightness * ageFactor, 0.0, 1.0);
-
-    out.color = float4(1.0, 1.0, 1.0, alpha);
+    out.color = float4(baseColor, alpha);
+    out.pointSize = max(1.0, uniforms.misc.y);
     return out;
 }
 


### PR DESCRIPTION
## Summary
- add a compute-driven lifting pass that turns the stereo vectorscope data into 3D positions using a configurable time lag
- render the lifted curve with a new Metal vertex shader, perspective transform, and depth-tinted color ramp
- expose the current audio sample rate so τ can follow the active hardware format

## Testing
- Not run (xcodebuild is unavailable in this container)


------
https://chatgpt.com/codex/tasks/task_e_68e3004367848325ba037f4f29326f11